### PR TITLE
keeperfx: Fix hash mismatch

### DIFF
--- a/bucket/keeperfx.json
+++ b/bucket/keeperfx.json
@@ -1,9 +1,10 @@
 {
-    "hash": "731b5414fed1a380c1f7452c6abe92d9bea64897efef423668433dec4278c158",
+    "version": "1.1.0",
+    "description": "Open source remake and Fan Expansion of Dungeon Keeper.",
+    "url": "https://github.com/dkfans/keeperfx/releases/download/v1.1.0/keeperfx_1_1_0_complete.7z",
+    "hash": "8c4d202b8e382e95296255692d5c76ebd470e4191c680a349acaa5e2469a50ed",
     "homepage": "https://keeperfx.net/",
     "license": "GPL-2.0-only",
-    "url": "https://github.com/dkfans/keeperfx/releases/download/v1.1.0/keeperfx_1_1_0_complete.7z",
-    "version": "1.1.0",
     "persist": "save",
     "bin": "keeperfx.exe",
     "shortcuts": [
@@ -20,6 +21,6 @@
         "github": "https://github.com/dkfans/keeperfx"
     },
     "autoupdate": {
-        "url": "https://github.com/dkfans/keeperfx/releases/download/v$version/keeperfx_$majorVersion_$minorVersion_$patchVersion_complete.7z"
+        "url": "https://github.com/dkfans/keeperfx/releases/download/v$version/keeperfx_$underscoreVersion_complete.7z"
     }
 }


### PR DESCRIPTION
fixes #1
Minor: moved around properties to match `ScoopInstaller/<bucket>` formatting, added `description`, and simplified version variable in `autoupdate.url`.